### PR TITLE
making InfoEventCallback call more defensive

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,7 +185,9 @@ func (pmc *Client) receiveLoop() {
 				if opError.Op == "read" && opError.Timeout() && opError.Temporary() {
 					msg := fmt.Sprintf("Client-side timeout from redis, redis did not respond: %v", opError)
 					log.Print(msg)
-					pmc.InfoEventCallback(msg)
+					if pmc.InfoEventCallback != nil {
+						pmc.InfoEventCallback(msg)
+					}
 					continue
 				}
 			}


### PR DESCRIPTION
Popped into my head that I should make this call a bit more defensive, in case some client sets it to nil. Not causing any active issues.